### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+if [ ! -z $DOWNGRADE ]; then
+  echo Downgrading docker-engine to: $DOWNGRADE ...
+  apt-get remove -y docker-engine
+  apt-get autoremove
+  apt-get autoclean
+  apt-get install -y  docker-engine=${DOWNGRADE}~trusty
+  echo "The new docker version is: "
+  docker -v
+fi
+
 /opt/erlang_app/generate_release.sh
 
 name=$IMAGE_APP_NAME


### PR DESCRIPTION
We need to use a specific version of the docker-engine. 
With this modification we can pass the DOWNGRADE variable to the environment with a specific version.
Example:
docker run --rm -v $(pwd):/opt/erlang_app -v /var/run/docker.sock:/var/run/docker.sock -e "DOWNGRADE=1.7.1-0" artefactop/erlang-builder
